### PR TITLE
ClickHouse 23.8; Lambda on Graviton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN npm run build:app
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as downloader
 WORKDIR /tmp
-RUN curl -LO https://s3.amazonaws.com/clickhouse-builds/PRs/53122/c1ba7c4cff64fa3bb1a1b16bf97fdad153947473/package_release/clickhouse-common-static-23.8.1.1004-amd64.tgz \
+RUN curl -LO https://github.com/ClickHouse/ClickHouse/releases/download/v23.8.2.7-lts/clickhouse-common-static-23.8.2.7-arm64.tgz \
     && mkdir clickhouse_bin \
     && dnf install tar gzip -y \
-    && tar xzf clickhouse-common-static-23.8.1.1004-amd64.tgz -C clickhouse_bin --strip-components=1
+    && tar xzf clickhouse-common-static-23.8.2.7-arm64.tgz -C clickhouse_bin --strip-components=1
 
 FROM public.ecr.aws/lambda/nodejs:18
 WORKDIR ${LAMBDA_TASK_ROOT}

--- a/lib/clickhouse-lambda-stack.ts
+++ b/lib/clickhouse-lambda-stack.ts
@@ -57,7 +57,7 @@ export class ClickhouseLambdaStack extends cdk.Stack {
         },
         timeout: cdk.Duration.seconds(300),
         memorySize: 2048,
-        architecture: lambda.Architecture.X86_64,
+        architecture: lambda.Architecture.ARM_64,
         logRetention: RetentionDays.ONE_WEEK,
       }
     );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. ClickHouse build v23.8.2.7-lts from github releases 2. Lambda on Graviton

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
